### PR TITLE
Update compiler.py to avoid the popup of the nvcc.exe console

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -62,7 +62,7 @@ def _run_cc(cmd, cwd, backend, log_stream=None):
         log = subprocess.check_output(cmd, cwd=cwd, env=env,
                                       stderr=subprocess.STDOUT,
                                       universal_newlines=True,
-                                      creationflags=subprocess.CREATE_NO_WINDOW)
+                                      creationflags=(subprocess.CREATE_NO_WINDOW if _win32 else None))
         if log_stream is not None:
             log_stream.write(log)
         return log

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -62,7 +62,7 @@ def _run_cc(cmd, cwd, backend, log_stream=None):
         log = subprocess.check_output(cmd, cwd=cwd, env=env,
                                       stderr=subprocess.STDOUT,
                                       universal_newlines=True,
-                                      creationflags=(subprocess.CREATE_NO_WINDOW if _win32 else None))
+                                      creationflags=(subprocess.CREATE_NO_WINDOW if _win32 else 0))
         if log_stream is not None:
             log_stream.write(log)
         return log

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -59,10 +59,11 @@ def _run_cc(cmd, cwd, backend, log_stream=None):
                 path = extra_path + os.pathsep + os.environ.get('PATH', '')
                 env = copy.deepcopy(env)
                 env['PATH'] = path
-        log = subprocess.check_output(cmd, cwd=cwd, env=env,
-                                      stderr=subprocess.STDOUT,
-                                      universal_newlines=True,
-                                      creationflags=(subprocess.CREATE_NO_WINDOW if _win32 else 0))
+        log = subprocess.check_output(
+            cmd, cwd=cwd, env=env,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            creationflags=(subprocess.CREATE_NO_WINDOW if _win32 else 0))
         if log_stream is not None:
             log_stream.write(log)
         return log

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -61,7 +61,8 @@ def _run_cc(cmd, cwd, backend, log_stream=None):
                 env['PATH'] = path
         log = subprocess.check_output(cmd, cwd=cwd, env=env,
                                       stderr=subprocess.STDOUT,
-                                      universal_newlines=True)
+                                      universal_newlines=True,
+                                      creationflags=subprocess.CREATE_NO_WINDOW)
         if log_stream is not None:
             log_stream.write(log)
         return log


### PR DESCRIPTION
The popup of the nvcc.exe console only happens in cythonized code.